### PR TITLE
Keep built artefacts out of the repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+MYMETA*
+Makefile
+blib/
+pm_to_blib


### PR DESCRIPTION
This will help in keeping the repo clean of generated files and OS artefacts, allowing this to be included cleanly in most build systems and (for myself) as a subrepo of my dotfiles repository without incorrectly reporting the state as dirty
